### PR TITLE
Post Synth simulation errors removed in script

### DIFF
--- a/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x16/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x16/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x16/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x24/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x24/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x24/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x24/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x24/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x24/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x32/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x32/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x32/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x8/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x8/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_32x8/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_default/raptor_run.sh
@@ -195,8 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -303,6 +301,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_default/raptor_run.sh
@@ -218,20 +218,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_default/raptor_run.sh
@@ -194,8 +194,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_16x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_16x4096/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_16x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_16x4096/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_16x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_16x4096/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_32x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_32x1024/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_32x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_32x1024/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_32x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_32x1024/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_64x2048/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_64x2048/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_64x2048/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_64x2048/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_64x2048/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_64x2048/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_default/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_default/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_async_fifo_default/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_128x12/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_128x12/raptor_run.sh
@@ -204,20 +204,7 @@ parse_cga exit 1; }
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ parse_cga exit 1; }
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_128x12/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_128x12/raptor_run.sh
@@ -194,8 +194,6 @@ parse_cga exit 1; }
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_128x12/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_128x12/raptor_run.sh
@@ -193,8 +193,7 @@ parse_cga exit 1; }
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_64x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_64x16/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_64x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_64x16/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_64x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_64x16/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_default/raptor_run.sh
@@ -195,8 +195,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_default/raptor_run.sh
@@ -196,8 +196,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -304,6 +302,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_default/raptor_run.sh
@@ -219,20 +219,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_16x32Lite/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_16x32Lite/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_16x32Lite/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_16x32Lite/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_16x32Lite/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_16x32Lite/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_32x32Lite/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_32x32Lite/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_32x32Lite/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_32x32Lite/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_32x32Lite/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_32x32Lite/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_8x32Lite/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_8x32Lite/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_8x32Lite/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_8x32Lite/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_8x32Lite/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_8x32Lite/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_default/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_default/raptor_run.sh
@@ -205,20 +205,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -237,20 +224,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_v2_default/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -308,6 +306,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_4x4/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_4x4/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_4x4/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_8x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_8x8/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_8x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_8x8/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_8x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_8x8/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_default/raptor_run.sh
@@ -195,8 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -303,6 +301,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_default/raptor_run.sh
@@ -218,20 +218,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_default/raptor_run.sh
@@ -194,8 +194,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_1x2/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_1x2/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_1x2/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_1x2/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_1x2/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_1x2/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_4x4/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_4x4/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_4x4/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_bram_1x2/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_bram_1x2/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_bram_1x2/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_bram_1x2/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_bram_1x2/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_v2_0_bram_1x2/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_dma_32x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dma_32x32/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_dma_32x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dma_32x32/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_dma_32x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dma_32x32/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_dma_64x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dma_64x16/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_dma_64x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dma_64x16/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_dma_64x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dma_64x16/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_dma_64x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dma_64x32/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_dma_64x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dma_64x32/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_dma_64x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dma_64x32/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_dma_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dma_default/raptor_run.sh
@@ -195,8 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -303,6 +301,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_dma_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dma_default/raptor_run.sh
@@ -218,20 +218,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_dma_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dma_default/raptor_run.sh
@@ -194,8 +194,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_dpram_128x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dpram_128x16/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_dpram_128x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dpram_128x16/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_dpram_128x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dpram_128x16/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_dpram_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dpram_default/raptor_run.sh
@@ -195,8 +195,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_dpram_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dpram_default/raptor_run.sh
@@ -196,8 +196,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -304,6 +302,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_dpram_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dpram_default/raptor_run.sh
@@ -219,20 +219,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_fifo_32x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_fifo_32x16/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_fifo_32x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_fifo_32x16/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_fifo_32x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_fifo_32x16/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_fifo_64x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_fifo_64x16/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_fifo_64x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_fifo_64x16/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_fifo_64x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_fifo_64x16/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_fifo_64x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_fifo_64x32/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_fifo_64x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_fifo_64x32/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_fifo_64x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_fifo_64x32/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_fifo_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_fifo_default/raptor_run.sh
@@ -195,8 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -303,6 +301,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_fifo_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_fifo_default/raptor_run.sh
@@ -218,20 +218,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_fifo_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_fifo_default/raptor_run.sh
@@ -194,8 +194,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_interconnect_16x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_interconnect_16x16/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_interconnect_16x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_interconnect_16x16/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_interconnect_16x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_interconnect_16x16/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_interconnect_1x1/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_interconnect_1x1/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_interconnect_1x1/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_interconnect_1x1/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_interconnect_1x1/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_interconnect_1x1/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_interconnect_8x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_interconnect_8x8/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_interconnect_8x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_interconnect_8x8/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_interconnect_8x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_interconnect_8x8/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_interconnect_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_interconnect_default/raptor_run.sh
@@ -195,8 +195,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_interconnect_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_interconnect_default/raptor_run.sh
@@ -196,8 +196,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -304,6 +302,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_interconnect_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_interconnect_default/raptor_run.sh
@@ -219,20 +219,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_ram_128x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_ram_128x16/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_ram_128x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_ram_128x16/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_ram_128x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_ram_128x16/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_ram_128x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_ram_128x8/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_ram_128x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_ram_128x8/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_ram_128x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_ram_128x8/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_ram_64x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_ram_64x16/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_ram_64x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_ram_64x16/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_ram_64x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_ram_64x16/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_ram_8x12/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_ram_8x12/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_ram_8x12/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_ram_8x12/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_ram_8x12/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_ram_8x12/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_ram_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_ram_default/raptor_run.sh
@@ -195,8 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -303,6 +301,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_ram_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_ram_default/raptor_run.sh
@@ -218,20 +218,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_ram_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_ram_default/raptor_run.sh
@@ -194,8 +194,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_register_128x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_register_128x32/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_register_128x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_register_128x32/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_register_128x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_register_128x32/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_register_64x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_register_64x32/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_register_64x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_register_64x32/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_register_64x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_register_64x32/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_register_64x64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_register_64x64/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axi_register_64x64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_register_64x64/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_register_64x64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_register_64x64/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_register_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_register_default/raptor_run.sh
@@ -195,8 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -303,6 +301,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axi_register_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_register_default/raptor_run.sh
@@ -218,20 +218,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axi_register_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_register_default/raptor_run.sh
@@ -194,8 +194,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_crossbar_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_crossbar_4x4/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_crossbar_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_crossbar_4x4/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_crossbar_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_crossbar_4x4/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_crossbar_8x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_crossbar_8x8/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_crossbar_8x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_crossbar_8x8/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_crossbar_8x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_crossbar_8x8/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_crossbar_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_crossbar_default/raptor_run.sh
@@ -195,8 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -303,6 +301,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_crossbar_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_crossbar_default/raptor_run.sh
@@ -218,20 +218,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_crossbar_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_crossbar_default/raptor_run.sh
@@ -194,8 +194,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_crossbar_v2_0_1x2/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_crossbar_v2_0_1x2/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_crossbar_v2_0_1x2/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_crossbar_v2_0_1x2/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_crossbar_v2_0_1x2/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_crossbar_v2_0_1x2/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_eio_max_probes_dw_64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_eio_max_probes_dw_64/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_eio_max_probes_dw_64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_eio_max_probes_dw_64/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_eio_max_probes_dw_64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_eio_max_probes_dw_64/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_eio_min_probes_dw_32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_eio_min_probes_dw_32/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_eio_min_probes_dw_32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_eio_min_probes_dw_32/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_eio_min_probes_dw_32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_eio_min_probes_dw_32/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_ethernet_1x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_ethernet_1x4/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_ethernet_1x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_ethernet_1x4/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_ethernet_1x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_ethernet_1x4/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_ethernet_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_ethernet_default/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_ethernet_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_ethernet_default/raptor_run.sh
@@ -205,20 +205,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -237,20 +224,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_ethernet_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_ethernet_default/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -308,6 +306,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_gpio_32x13/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_gpio_32x13/raptor_run.sh
@@ -204,20 +204,7 @@ parse_cga exit 1; }
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ parse_cga exit 1; }
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_gpio_32x13/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_gpio_32x13/raptor_run.sh
@@ -194,8 +194,6 @@ parse_cga exit 1; }
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_gpio_32x13/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_gpio_32x13/raptor_run.sh
@@ -193,8 +193,7 @@ parse_cga exit 1; }
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_gpio_32x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_gpio_32x8/raptor_run.sh
@@ -204,20 +204,7 @@ parse_cga exit 1; }
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ parse_cga exit 1; }
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_gpio_32x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_gpio_32x8/raptor_run.sh
@@ -194,8 +194,6 @@ parse_cga exit 1; }
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_gpio_32x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_gpio_32x8/raptor_run.sh
@@ -193,8 +193,7 @@ parse_cga exit 1; }
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_gpio_64x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_gpio_64x16/raptor_run.sh
@@ -204,20 +204,7 @@ parse_cga exit 1; }
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ parse_cga exit 1; }
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_gpio_64x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_gpio_64x16/raptor_run.sh
@@ -194,8 +194,6 @@ parse_cga exit 1; }
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_gpio_64x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_gpio_64x16/raptor_run.sh
@@ -193,8 +193,7 @@ parse_cga exit 1; }
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_gpio_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_gpio_default/raptor_run.sh
@@ -204,20 +204,7 @@ parse_cga exit 1; }
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ parse_cga exit 1; }
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_gpio_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_gpio_default/raptor_run.sh
@@ -194,8 +194,6 @@ parse_cga exit 1; }
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_gpio_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_gpio_default/raptor_run.sh
@@ -193,8 +193,7 @@ parse_cga exit 1; }
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_interconnect_16x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_interconnect_16x16/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_interconnect_16x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_interconnect_16x16/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_interconnect_16x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_interconnect_16x16/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_interconnect_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_interconnect_4x4/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_interconnect_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_interconnect_4x4/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_interconnect_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_interconnect_4x4/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_interconnect_8x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_interconnect_8x8/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_interconnect_8x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_interconnect_8x8/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_interconnect_8x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_interconnect_8x8/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_interconnect_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_interconnect_default/raptor_run.sh
@@ -219,20 +219,7 @@ parse_cga exit 1; }
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_interconnect_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_interconnect_default/raptor_run.sh
@@ -195,8 +195,7 @@ parse_cga exit 1; }
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_interconnect_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_interconnect_default/raptor_run.sh
@@ -196,8 +196,6 @@ parse_cga exit 1; }
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -304,6 +302,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_quadspi_Default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_quadspi_Default/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_quadspi_Default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_quadspi_Default/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_quadspi_Default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_quadspi_Default/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_uart16550_16x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_uart16550_16x16/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_uart16550_16x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_uart16550_16x16/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_uart16550_16x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_uart16550_16x16/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_uart16550_16x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_uart16550_16x32/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_uart16550_16x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_uart16550_16x32/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_uart16550_16x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_uart16550_16x32/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_uart16550_32x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_uart16550_32x32/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_uart16550_32x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_uart16550_32x32/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_uart16550_32x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_uart16550_32x32/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_uart16550_32x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_uart16550_32x8/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_uart16550_32x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_uart16550_32x8/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_uart16550_32x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_uart16550_32x8/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axil_uart16550_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_uart16550_default/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axil_uart16550_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_uart16550_default/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axil_uart16550_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_uart16550_default/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_adapter_1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_adapter_1024/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_adapter_1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_adapter_1024/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_adapter_1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_adapter_1024/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_adapter_2048/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_adapter_2048/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_adapter_2048/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_adapter_2048/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_adapter_2048/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_adapter_2048/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_adapter_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_adapter_default/raptor_run.sh
@@ -195,8 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -303,6 +301,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_adapter_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_adapter_default/raptor_run.sh
@@ -218,20 +218,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_adapter_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_adapter_default/raptor_run.sh
@@ -194,8 +194,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_2048x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_2048x16/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_2048x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_2048x16/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_2048x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_2048x16/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_4096x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_4096x32/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_4096x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_4096x32/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_4096x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_4096x32/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_4096x64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_4096x64/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_4096x64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_4096x64/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_4096x64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_4096x64/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_default/raptor_run.sh
@@ -195,8 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -303,6 +301,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_default/raptor_run.sh
@@ -218,20 +218,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_default/raptor_run.sh
@@ -194,8 +194,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_broadcast_4master/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_broadcast_4master/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_broadcast_4master/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_broadcast_4master/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_broadcast_4master/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_broadcast_4master/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_broadcast_6master/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_broadcast_6master/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_broadcast_6master/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_broadcast_6master/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_broadcast_6master/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_broadcast_6master/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_broadcast_8master/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_broadcast_8master/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_broadcast_8master/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_broadcast_8master/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_broadcast_8master/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_broadcast_8master/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_broadcast_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_broadcast_default/raptor_run.sh
@@ -195,8 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -303,6 +301,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_broadcast_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_broadcast_default/raptor_run.sh
@@ -218,20 +218,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_broadcast_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_broadcast_default/raptor_run.sh
@@ -194,8 +194,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_fifo_32768x64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_fifo_32768x64/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_fifo_32768x64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_fifo_32768x64/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_fifo_32768x64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_fifo_32768x64/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_fifo_4096x64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_fifo_4096x64/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_fifo_4096x64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_fifo_4096x64/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_fifo_4096x64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_fifo_4096x64/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_fifo_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_fifo_default/raptor_run.sh
@@ -195,8 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -303,6 +301,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_fifo_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_fifo_default/raptor_run.sh
@@ -218,20 +218,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_fifo_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_fifo_default/raptor_run.sh
@@ -194,8 +194,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_interconnect_2x2/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_interconnect_2x2/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_interconnect_2x2/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_interconnect_2x2/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_interconnect_2x2/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_interconnect_2x2/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_interconnect_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_interconnect_4x4/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_interconnect_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_interconnect_4x4/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_interconnect_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_interconnect_4x4/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_interconnect_8x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_interconnect_8x8/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_interconnect_8x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_interconnect_8x8/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_interconnect_8x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_interconnect_8x8/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_interconnect_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_interconnect_default/raptor_run.sh
@@ -218,20 +218,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_interconnect_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_interconnect_default/raptor_run.sh
@@ -194,8 +194,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_interconnect_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_interconnect_default/raptor_run.sh
@@ -195,8 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -304,6 +302,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_pipeline_register_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_pipeline_register_default/raptor_run.sh
@@ -195,8 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -303,6 +301,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_pipeline_register_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_pipeline_register_default/raptor_run.sh
@@ -218,20 +218,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_pipeline_register_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_pipeline_register_default/raptor_run.sh
@@ -194,8 +194,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_1x1/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_1x1/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_1x1/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_1x1/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_1x1/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_1x1/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_3x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_3x8/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_3x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_3x8/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_3x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_3x8/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_4x3/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_4x3/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_4x3/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_4x3/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_4x3/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_4x3/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_4x4/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_4x4/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_4x4/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_default/raptor_run.sh
@@ -195,8 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -303,6 +301,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_default/raptor_run.sh
@@ -218,20 +218,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_default/raptor_run.sh
@@ -194,8 +194,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_switch_1x1/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_switch_1x1/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_switch_1x1/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_switch_1x1/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_switch_1x1/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_switch_1x1/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_switch_3x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_switch_3x8/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_switch_3x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_switch_3x8/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_switch_3x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_switch_3x8/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_switch_4x3/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_switch_4x3/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_switch_4x3/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_switch_4x3/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_switch_4x3/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_switch_4x3/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_switch_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_switch_4x4/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_switch_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_switch_4x4/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_switch_4x4/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_switch_4x4/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_switch_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_switch_default/raptor_run.sh
@@ -195,8 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -303,6 +301,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_switch_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_switch_default/raptor_run.sh
@@ -218,20 +218,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_switch_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_switch_default/raptor_run.sh
@@ -194,8 +194,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_uart_5/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_uart_5/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_uart_5/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_uart_5/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_uart_5/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_uart_5/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_uart_64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_uart_64/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_uart_64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_uart_64/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/axis_uart_64/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_uart_64/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/axis_uart_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_uart_default/raptor_run.sh
@@ -194,8 +194,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/axis_uart_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_uart_default/raptor_run.sh
@@ -195,8 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -220,27 +218,27 @@ IP_PATH="./$design/run_1/IPs"
     echo "packing">>raptor_tcl.tcl  
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
-        if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
-            # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
-            [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
-            [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 
-        else
-            echo ""
-        fi
+    if [ "$post_route_sim" == true ]; then 
+        echo "# Open the input file in read mode">>raptor_tcl.tcl 
+        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
+        echo "# Read the file content">>raptor_tcl.tcl 
+        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
+        echo "# Close the input file after reading">>raptor_tcl.tcl 
+        echo "close \$input_file">>raptor_tcl.tcl 
+        echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
+        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
+        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
+        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
+        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
+        echo "# Close the file">>raptor_tcl.tcl 
+        echo "close \$output_file">>raptor_tcl.tcl 
+        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
+        [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
+        [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 
+    else
+        echo ""
+    fi
     echo "sta">>raptor_tcl.tcl  
     echo "power">>raptor_tcl.tcl  
     echo "bitstream $bitstream">>raptor_tcl.tcl  
@@ -311,6 +309,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCDEFGH_18X18_12x11_8X8_13x13_signed/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCDEFGH_18X18_12x11_8X8_13x13_signed/raptor_run.sh
@@ -195,7 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -308,6 +307,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCDEFGH_18X18_12x11_8X8_13x13_signed/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCDEFGH_18X18_12x11_8X8_13x13_signed/raptor_run.sh
@@ -207,20 +207,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -239,20 +226,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCDEFGH_19X17_5x13_12X8_10x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCDEFGH_19X17_5x13_12X8_10x16/raptor_run.sh
@@ -195,7 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -308,6 +307,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCDEFGH_19X17_5x13_12X8_10x16/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCDEFGH_19X17_5x13_12X8_10x16/raptor_run.sh
@@ -207,20 +207,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -239,20 +226,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCDEFGH_20X18_20x18_20X18_20x18/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCDEFGH_20X18_20x18_20X18_20x18/raptor_run.sh
@@ -195,7 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -308,6 +307,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCDEFGH_20X18_20x18_20X18_20x18/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCDEFGH_20X18_20x18_20X18_20x18/raptor_run.sh
@@ -207,20 +207,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -239,20 +226,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCD_10X15_12x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCD_10X15_12x8/raptor_run.sh
@@ -195,7 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -308,6 +307,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCD_10X15_12x8/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCD_10X15_12x8/raptor_run.sh
@@ -207,20 +207,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -239,20 +226,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCD_15X10_7x2_signed/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCD_15X10_7x2_signed/raptor_run.sh
@@ -195,7 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -308,6 +307,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCD_15X10_7x2_signed/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCD_15X10_7x2_signed/raptor_run.sh
@@ -207,20 +207,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -239,20 +226,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCD_20X18_20x18/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCD_20X18_20x18/raptor_run.sh
@@ -195,7 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -308,6 +307,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCD_20X18_20x18/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_ABCD_20X18_20x18/raptor_run.sh
@@ -207,20 +207,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -239,20 +226,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_16X10_signed/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_16X10_signed/raptor_run.sh
@@ -195,7 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -308,6 +307,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_16X10_signed/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_16X10_signed/raptor_run.sh
@@ -207,20 +207,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -239,20 +226,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_20X18/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_20X18/raptor_run.sh
@@ -195,7 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -308,6 +307,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_20X18/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_20X18/raptor_run.sh
@@ -207,20 +207,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -239,20 +226,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_34x34_enhanced/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_34x34_enhanced/raptor_run.sh
@@ -196,7 +196,6 @@ parse_cga exit 1; }
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -309,6 +308,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_34x34_enhanced/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_34x34_enhanced/raptor_run.sh
@@ -208,20 +208,7 @@ parse_cga exit 1; }
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -240,20 +227,7 @@ parse_cga exit 1; }
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_36x36_pipeline/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_36x36_pipeline/raptor_run.sh
@@ -196,7 +196,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -309,6 +308,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_36x36_pipeline/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_36x36_pipeline/raptor_run.sh
@@ -208,20 +208,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -240,20 +227,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_36x36_signed/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_36x36_signed/raptor_run.sh
@@ -196,7 +196,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -309,6 +308,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_36x36_signed/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_36x36_signed/raptor_run.sh
@@ -208,20 +208,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -240,20 +227,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_51x51_enhanced/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_51x51_enhanced/raptor_run.sh
@@ -196,7 +196,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -309,6 +308,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_51x51_enhanced/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_51x51_enhanced/raptor_run.sh
@@ -208,20 +208,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -240,20 +227,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_51x51_pipeline_signed/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_51x51_pipeline_signed/raptor_run.sh
@@ -196,7 +196,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -309,6 +308,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_51x51_pipeline_signed/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_51x51_pipeline_signed/raptor_run.sh
@@ -208,20 +208,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -240,20 +227,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_54x54/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_54x54/raptor_run.sh
@@ -196,7 +196,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -309,6 +308,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_54x54/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_54x54/raptor_run.sh
@@ -208,20 +208,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -240,20 +227,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_5x10/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_5x10/raptor_run.sh
@@ -195,7 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -308,6 +307,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_5x10/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_5x10/raptor_run.sh
@@ -207,20 +207,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -239,20 +226,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_64x64_enhanced_signed/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_64x64_enhanced_signed/raptor_run.sh
@@ -196,7 +196,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -309,6 +308,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_64x64_enhanced_signed/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_64x64_enhanced_signed/raptor_run.sh
@@ -208,20 +208,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -240,20 +227,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_72x72/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_72x72/raptor_run.sh
@@ -196,7 +196,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -309,6 +308,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_72x72/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_72x72/raptor_run.sh
@@ -208,20 +208,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -240,20 +227,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_72x72_pipeline/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_72x72_pipeline/raptor_run.sh
@@ -196,7 +196,6 @@ parse_cga exit 1; }
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/dsp_test.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -309,6 +308,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_72x72_pipeline/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/dsp_generator_AB_72x72_pipeline/raptor_run.sh
@@ -208,20 +208,7 @@ parse_cga exit 1; }
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -240,20 +227,7 @@ parse_cga exit 1; }
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/fifo_generator_bram_async_128x32768/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fifo_generator_bram_async_128x32768/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/fifo_generator_bram_async_128x32768/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fifo_generator_bram_async_128x32768/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/fifo_generator_bram_async_128x32768/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fifo_generator_bram_async_128x32768/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/fifo_generator_bram_sync_73x3072/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fifo_generator_bram_sync_73x3072/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/fifo_generator_bram_sync_73x3072/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fifo_generator_bram_sync_73x3072/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/fifo_generator_bram_sync_73x3072/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fifo_generator_bram_sync_73x3072/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/fifo_generator_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fifo_generator_default/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/fifo_generator_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fifo_generator_default/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/fifo_generator_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fifo_generator_default/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/fifo_generator_dram_async_23x512/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fifo_generator_dram_async_23x512/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/fifo_generator_dram_async_23x512/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fifo_generator_dram_async_23x512/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/fifo_generator_dram_async_23x512/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fifo_generator_dram_async_23x512/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/fifo_generator_dram_sync_50x10000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fifo_generator_dram_sync_50x10000/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/fifo_generator_dram_sync_50x10000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fifo_generator_dram_sync_50x10000/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/fifo_generator_dram_sync_50x10000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fifo_generator_dram_sync_50x10000/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/fir_generator_default_six_coefficients_signed/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fir_generator_default_six_coefficients_signed/raptor_run.sh
@@ -195,7 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/testbench.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -308,6 +307,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/fir_generator_default_six_coefficients_signed/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fir_generator_default_six_coefficients_signed/raptor_run.sh
@@ -207,20 +207,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -239,20 +226,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/fir_generator_performance_six_coefficients_signed/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fir_generator_performance_six_coefficients_signed/raptor_run.sh
@@ -195,7 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
         echo "add_simulation_file $main_path/results_dir/$design/run_1/IPs/rapidsilicon/ip/$ip_name/v1_0/$design/sim/testbench.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -308,6 +307,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/fir_generator_performance_six_coefficients_signed/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/fir_generator_performance_six_coefficients_signed/raptor_run.sh
@@ -207,20 +207,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -239,20 +226,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/i2c_master_axil_slave_2x2/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/i2c_master_axil_slave_2x2/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/i2c_master_axil_slave_2x2/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/i2c_master_axil_slave_2x2/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/i2c_master_axil_slave_2x2/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/i2c_master_axil_slave_2x2/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/i2c_master_axil_slave_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/i2c_master_axil_slave_default/raptor_run.sh
@@ -218,20 +218,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/i2c_master_axil_slave_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/i2c_master_axil_slave_default/raptor_run.sh
@@ -194,8 +194,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/i2c_master_axil_slave_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/i2c_master_axil_slave_default/raptor_run.sh
@@ -195,8 +195,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -304,6 +302,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_32x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_32x32/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_32x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_32x32/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_32x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_32x32/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_64x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_64x32/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_64x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_64x32/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_64x32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_64x32/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_default/raptor_run.sh
@@ -195,8 +195,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_default/raptor_run.sh
@@ -196,8 +196,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -305,6 +303,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_default/raptor_run.sh
@@ -219,20 +219,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/jtag_axi_32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/jtag_axi_32/raptor_run.sh
@@ -204,20 +204,7 @@ parse_cga exit 1; }
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ parse_cga exit 1; }
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/jtag_axi_32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/jtag_axi_32/raptor_run.sh
@@ -194,8 +194,6 @@ parse_cga exit 1; }
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/jtag_axi_32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/jtag_axi_32/raptor_run.sh
@@ -193,8 +193,7 @@ parse_cga exit 1; }
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocla_mode_axilite4_mem_depth_32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocla_mode_axilite4_mem_depth_32/raptor_run.sh
@@ -192,8 +192,7 @@ parse_cga exit 1; }
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocla_mode_axilite4_mem_depth_32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocla_mode_axilite4_mem_depth_32/raptor_run.sh
@@ -193,8 +193,6 @@ parse_cga exit 1; }
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -306,6 +304,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocla_mode_axilite4_mem_depth_32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocla_mode_axilite4_mem_depth_32/raptor_run.sh
@@ -203,20 +203,7 @@ parse_cga exit 1; }
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -235,20 +222,7 @@ parse_cga exit 1; }
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocla_probe1024_mem_depth_32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocla_probe1024_mem_depth_32/raptor_run.sh
@@ -192,8 +192,7 @@ parse_cga exit 1; }
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocla_probe1024_mem_depth_32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocla_probe1024_mem_depth_32/raptor_run.sh
@@ -193,8 +193,6 @@ parse_cga exit 1; }
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -306,6 +304,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocla_probe1024_mem_depth_32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocla_probe1024_mem_depth_32/raptor_run.sh
@@ -203,20 +203,7 @@ parse_cga exit 1; }
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -235,20 +222,7 @@ parse_cga exit 1; }
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocla_probe_32_mem_depth_32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocla_probe_32_mem_depth_32/raptor_run.sh
@@ -192,8 +192,7 @@ parse_cga exit 1; }
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocla_probe_32_mem_depth_32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocla_probe_32_mem_depth_32/raptor_run.sh
@@ -193,8 +193,6 @@ parse_cga exit 1; }
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -306,6 +304,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocla_probe_32_mem_depth_32/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocla_probe_32_mem_depth_32/raptor_run.sh
@@ -203,20 +203,7 @@ parse_cga exit 1; }
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -235,20 +222,7 @@ parse_cga exit 1; }
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocla_probe_64_mem_depth_512_eio_enable/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocla_probe_64_mem_depth_512_eio_enable/raptor_run.sh
@@ -192,8 +192,7 @@ parse_cga exit 1; }
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocla_probe_64_mem_depth_512_eio_enable/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocla_probe_64_mem_depth_512_eio_enable/raptor_run.sh
@@ -193,8 +193,6 @@ parse_cga exit 1; }
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -306,6 +304,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocla_probe_64_mem_depth_512_eio_enable/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocla_probe_64_mem_depth_512_eio_enable/raptor_run.sh
@@ -203,20 +203,7 @@ parse_cga exit 1; }
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -235,20 +222,7 @@ parse_cga exit 1; }
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_110x8192/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_110x8192/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_110x8192/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_110x8192/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_110x8192/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_110x8192/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_120x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_120x1024/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_120x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_120x1024/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_120x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_120x1024/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_18x2048_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_18x2048_mem_init/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_18x2048_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_18x2048_mem_init/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_18x2048_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_18x2048_mem_init/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_20x32768/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_20x32768/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_20x32768/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_20x32768/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_20x32768/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_20x32768/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_25x2000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_25x2000/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_25x2000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_25x2000/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_25x2000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_25x2000/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_2x16384/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_2x16384/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_2x16384/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_2x16384/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_2x16384/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_2x16384/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_32x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_32x1024/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_32x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_32x1024/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_32x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_32x1024/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_32x10240/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_32x10240/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_32x10240/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_32x10240/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_32x10240/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_32x10240/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_35x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_35x4096/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_35x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_35x4096/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_35x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_35x4096/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_36x8192_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_36x8192_mem_init/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_36x8192_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_36x8192_mem_init/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_36x8192_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_36x8192_mem_init/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_37x5000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_37x5000/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_37x5000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_37x5000/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_37x5000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_37x5000/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_39x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_39x1024/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_39x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_39x1024/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_39x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_39x1024/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_50x3500_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_50x3500_mem_init/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_50x3500_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_50x3500_mem_init/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_50x3500_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_50x3500_mem_init/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_64x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_64x4096/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_64x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_64x4096/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_64x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_64x4096/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_79x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_79x4096/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_79x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_79x4096/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_79x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_79x4096/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_99x25000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_99x25000/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_99x25000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_99x25000/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sdp_99x25000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sdp_99x25000/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_100x4096_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_100x4096_mem_init/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_100x4096_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_100x4096_mem_init/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_100x4096_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_100x4096_mem_init/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_10x32768/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_10x32768/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_10x32768/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_10x32768/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_10x32768/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_10x32768/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_110x8192/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_110x8192/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_110x8192/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_110x8192/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_110x8192/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_110x8192/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_120x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_120x1024/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_120x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_120x1024/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_120x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_120x1024/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_128x1024_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_128x1024_mem_init/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_128x1024_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_128x1024_mem_init/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_128x1024_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_128x1024_mem_init/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_14x4500_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_14x4500_mem_init/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_14x4500_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_14x4500_mem_init/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_14x4500_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_14x4500_mem_init/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_18x2050/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_18x2050/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_18x2050/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_18x2050/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_18x2050/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_18x2050/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_18x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_18x4096/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_18x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_18x4096/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_18x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_18x4096/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_20x16384/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_20x16384/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_20x16384/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_20x16384/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_20x16384/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_20x16384/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_20x512_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_20x512_mem_init/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_20x512_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_20x512_mem_init/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_20x512_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_20x512_mem_init/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x1024/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x1024/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x1024/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x2000_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x2000_mem_init/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x2000_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x2000_mem_init/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x2000_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x2000_mem_init/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x32768/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x32768/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x32768/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x32768/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x32768/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_32x32768/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_33x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_33x1024/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_33x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_33x1024/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_33x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_33x1024/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_37x5000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_37x5000/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_37x5000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_37x5000/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_37x5000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_37x5000/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_64x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_64x1024/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_64x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_64x1024/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_64x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_64x1024/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_79x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_79x4096/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_79x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_79x4096/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_79x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_79x4096/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_99x25000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_99x25000/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_99x25000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_99x25000/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_sp_99x25000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_sp_99x25000/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_110x8192/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_110x8192/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_110x8192/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_110x8192/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_110x8192/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_110x8192/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_120x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_120x1024/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_120x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_120x1024/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_120x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_120x1024/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_128x2048/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_128x2048/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_128x2048/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_128x2048/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_128x2048/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_128x2048/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_18x32768_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_18x32768_mem_init/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_18x32768_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_18x32768_mem_init/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_18x32768_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_18x32768_mem_init/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_20x32768/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_20x32768/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_20x32768/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_20x32768/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_20x32768/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_20x32768/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_25x16384_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_25x16384_mem_init/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_25x16384_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_25x16384_mem_init/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_25x16384_mem_init/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_25x16384_mem_init/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_25x2000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_25x2000/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_25x2000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_25x2000/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_25x2000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_25x2000/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_2x16384/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_2x16384/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_2x16384/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_2x16384/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_2x16384/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_2x16384/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_32x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_32x1024/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_32x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_32x1024/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_32x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_32x1024/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_32x20480/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_32x20480/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_32x20480/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_32x20480/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_32x20480/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_32x20480/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_35x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_35x4096/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_35x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_35x4096/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_35x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_35x4096/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_37x5000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_37x5000/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_37x5000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_37x5000/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_37x5000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_37x5000/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_39x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_39x1024/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_39x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_39x1024/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_39x1024/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_39x1024/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_79x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_79x4096/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_79x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_79x4096/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_79x4096/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_79x4096/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_99x25000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_99x25000/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_99x25000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_99x25000/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/ocm_tdp_99x25000/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/ocm_tdp_99x25000/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/priority_encoder_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/priority_encoder_default/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/priority_encoder_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/priority_encoder_default/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/priority_encoder_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/priority_encoder_default/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/reset_release_3/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/reset_release_3/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/reset_release_3/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/reset_release_3/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/reset_release_3/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/reset_release_3/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/reset_release_5/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/reset_release_5/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/reset_release_5/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/reset_release_5/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/reset_release_5/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/reset_release_5/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/reset_release_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/reset_release_default/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/reset_release_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/reset_release_default/raptor_run.sh
@@ -205,20 +205,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -237,20 +224,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/reset_release_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/reset_release_default/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -308,6 +306,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_default/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_default/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_default/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_mmu/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_mmu/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_mmu/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_mmu/raptor_run.sh
@@ -205,20 +205,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -237,20 +224,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 

--- a/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_mmu/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_mmu/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -308,6 +306,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_plic_clint/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_plic_clint/raptor_run.sh
@@ -193,8 +193,7 @@ IP_PATH="./$design/run_1/IPs"
     ##vary design to design
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
-    if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-    else
+    if [ "$post_synth_sim" == false ] && [ "$post_route_sim" == false ] && [ "$bitstream_sim" == false ]; then
         echo ""
     fi
 

--- a/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_plic_clint/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_plic_clint/raptor_run.sh
@@ -194,8 +194,6 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$add_constraint_file" ] && echo "" || echo "add_constraint_file $add_constraint_file">>raptor_tcl.tcl 
     
     if [ "$post_synth_sim" == true ] || [ "$post_route_sim" == true ] || [ "$bitstream_sim" == true ]; then
-        echo "add_simulation_file ./sim/co_sim_tb/co_sim_$design.v ./rtl/$design.v">>raptor_tcl.tcl 
-        echo "set_top_testbench co_sim_$design">>raptor_tcl.tcl 
     else
         echo ""
     fi
@@ -307,6 +305,5 @@ echo -e "\n\n#########Raptor Performance Data#########" >> results.log
 cat raptor_perf.log >> results.log
 echo -e "#############################################\n" >> results.log
 
-[ -f $main_path/sim/co_sim_tb/co_sim_$design\_temp.v ] && mv $main_path/sim/co_sim_tb/co_sim_$design\_temp.v $main_path/sim/co_sim_tb/co_sim_$design.v || echo ""
 end_time
 parse_cga

--- a/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_plic_clint/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/vexriscv_cpu_plic_clint/raptor_run.sh
@@ -204,20 +204,7 @@ IP_PATH="./$design/run_1/IPs"
     [ -z "$synth_options" ] && echo "" || echo "synth_options $synth_options">>raptor_tcl.tcl
     [ -z "$strategy" ] && echo "" || echo "synthesize $strategy">>raptor_tcl.tcl  
     if [ "$post_synth_sim" == true ]; then 
-        echo "# Open the input file in read mode">>raptor_tcl.tcl 
-        echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-        echo "# Read the file content">>raptor_tcl.tcl 
-        echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-        echo "# Close the input file after reading">>raptor_tcl.tcl 
-        echo "close \$input_file">>raptor_tcl.tcl 
-        echo "set modified_content [string map {\"$design(\" \"${design}_post_synth(\"} \$file_content]">>raptor_tcl.tcl 
-        echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-        echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/$design\_post_synth.v\" w]">>raptor_tcl.tcl
-        echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-        echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-        echo "# Close the file">>raptor_tcl.tcl 
-        echo "close \$output_file">>raptor_tcl.tcl 
-        echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+        
         [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus gate" >> raptor_tcl.tcl || echo "simulation_options compilation verilator gate" >> raptor_tcl.tcl
         [ "$tool_name" = "iverilog" ] && echo "simulate gate icarus">>raptor_tcl.tcl || echo "simulate gate verilator">>raptor_tcl.tcl 
     else
@@ -236,20 +223,7 @@ IP_PATH="./$design/run_1/IPs"
     echo "place">>raptor_tcl.tcl  
     echo "route">>raptor_tcl.tcl  
         if [ "$post_route_sim" == true ]; then 
-            echo "# Open the input file in read mode">>raptor_tcl.tcl 
-            echo "set input_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" r]">>raptor_tcl.tcl 
-            echo "# Read the file content">>raptor_tcl.tcl 
-            echo "set file_content [read \$input_file]">>raptor_tcl.tcl 
-            echo "# Close the input file after reading">>raptor_tcl.tcl 
-            echo "close \$input_file">>raptor_tcl.tcl 
-            echo "set modified_content [string map {\"module $design(\" \"module ${design}_post_route (\"} \$file_content]">>raptor_tcl.tcl 
-            echo "# Open the file again, this time in write mode to overwrite the old content">>raptor_tcl.tcl 
-            echo "set output_file [open \"$design/run_1/synth_1_1/synthesis/post_pnr_wrapper_$design\_post_synth.v\" w]">>raptor_tcl.tcl
-            echo "# Write the modified content back to the file">>raptor_tcl.tcl 
-            echo "puts \$output_file \$modified_content">>raptor_tcl.tcl 
-            echo "# Close the file">>raptor_tcl.tcl 
-            echo "close \$output_file">>raptor_tcl.tcl 
-            echo "puts \"Modification completed.\"">>raptor_tcl.tcl 
+            
             # echo "exec python3 $main_path/../../../scripts/post_route_script.py $design">>raptor_tcl.tcl 
             [ "$tool_name" = "iverilog" ] && echo "simulation_options compilation icarus -DPNR=1 pnr" >> raptor_tcl.tcl || echo "simulation_options compilation verilator -DPNR=1 pnr" >> raptor_tcl.tcl
             [ "$tool_name" = "iverilog" ] && echo "simulate pnr icarus">>raptor_tcl.tcl || echo "simulate pnr verilator">>raptor_tcl.tcl 


### PR DESCRIPTION
This just enables post-synth simulations of IP_Catalog designs by removing bad portion of code in raptor_run.sh scripts, debugging of simulation failures may be required for designs on an individual basis.