### PR TITLE
removed redundant simlib dependency in IP_Catalog_Designs

### DIFF
--- a/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi2axilite_bridge_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axi_cdma_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_cdma_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axi_crossbar_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_crossbar_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axi_dma_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dma_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axi_dpram_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_dpram_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axi_fifo_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_fifo_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axi_interconnect_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_interconnect_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axi_ram_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_ram_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axi_register_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axi_register_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axil_crossbar_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_crossbar_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axil_interconnect_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axil_interconnect_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axis_adapter_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_adapter_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_async_fifo_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axis_broadcast_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_broadcast_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axis_fifo_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_fifo_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axis_interconnect_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_interconnect_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axis_pipeline_register_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_pipeline_register_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_ram_switch_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axis_switch_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_switch_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/axis_uart_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/axis_uart_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/i2c_master_axil_slave_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/i2c_master_axil_slave_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir
 [ ! -d $PWD/results_dir ] && mkdir $PWD/results_dir

--- a/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_default/raptor_run.sh
+++ b/RTL_testcases/IP_Catalog_Designs/i2c_slave_axil_master_default/raptor_run.sh
@@ -85,7 +85,7 @@ parse_cga exit; }
 lib_fix_path="${raptor_path:(-11)}"
 library=${raptor_path/$lib_fix_path//share/raptor/sim_models}
 primitive_sim_path=$(find $library -wholename "*/rapidsilicon/genesis3/FPGA_PRIMITIVES_MODELS/sim_models/verilog/*.v" -exec dirname {} \; -quit)
-sim_lib=`find $library -wholename "*/rapidsilicon/genesis3/simlib.v"`
+
 
 #removing and creating raptor_testcase_files
 #rm -fR $PWD/results_dir


### PR DESCRIPTION
simlib.v was not being used even earlier, this PR just cleans up the code by removing the path to simlib.v altogether.